### PR TITLE
Display arsaker from medisinsk- and arbeidsrelatert-arsaker

### DIFF
--- a/client/src/components/infopanel/layout/EnkelCheckbox.tsx
+++ b/client/src/components/infopanel/layout/EnkelCheckbox.tsx
@@ -12,17 +12,29 @@ interface EnkelCheckboxProps {
   innrykk?: boolean;
   bold?: boolean;
   vis?: boolean;
+  listItems?: string[];
 }
 
-const EnkelCheckbox = ({ tittel, checked, margin, innrykk, bold, vis = true }: EnkelCheckboxProps) => {
+const EnkelCheckbox = ({ tittel, checked, margin, innrykk, bold, vis = true, listItems }: EnkelCheckboxProps) => {
   if (!vis) {
     return null;
   }
 
-  const innhold = (
-    <div style={{ display: 'flex', alignItems: 'center' }}>
-      <img style={{ marginRight: '1rem' }} src={checked ? sjekkboks : sjekkboksKryss} alt="sjekkboks ikon" />
-      <span>{bold ? <Element>{tittel}</Element> : <Normaltekst>{tittel}</Normaltekst>}</span>
+  const innhold: JSX.Element = (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <img style={{ marginRight: '1rem' }} src={checked ? sjekkboks : sjekkboksKryss} alt="sjekkboks ikon" />
+        <span>{bold ? <Element>{tittel}</Element> : <Normaltekst>{tittel}</Normaltekst>}</span>
+      </div>
+      {!!listItems?.length && (
+        <ul style={{ marginTop: '1rem', marginLeft: '2.5rem' }}>
+          {listItems.map((item) => (
+            <li>
+              <Normaltekst>{item}</Normaltekst>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 

--- a/client/src/components/infopanel/utdypendeelementer/MulighetForArbeid.tsx
+++ b/client/src/components/infopanel/utdypendeelementer/MulighetForArbeid.tsx
@@ -5,7 +5,7 @@ import SeksjonMedTittel from '../layout/SeksjonMedTittel';
 import ElementMedTekst from '../layout/ElementMedTekst';
 import EnkelCheckbox from '../layout/EnkelCheckbox';
 import { tilLesbarPeriodeMedArstall } from '../../../utils/datoUtils';
-import { Periode } from '../../../types/sykmelding';
+import { ArbeidsrelatertArsakTypeValues, MedisinskArsakTypeValues, Periode } from '../../../types/sykmelding';
 
 interface MulighetForArbeidProps {
   perioder: Periode[];
@@ -74,6 +74,9 @@ const MulighetForArbeid = ({ perioder }: MulighetForArbeidProps) => {
             tittel="4.3.3. Medisinske årsaker hindrer arbeidsrelatert aktivitet"
             margin
             checked={!!periode.aktivitetIkkeMulig?.medisinskArsak}
+            listItems={periode.aktivitetIkkeMulig?.medisinskArsak?.arsak.map(
+              (arsak) => MedisinskArsakTypeValues[arsak],
+            )}
             bold
             vis
           />
@@ -89,6 +92,9 @@ const MulighetForArbeid = ({ perioder }: MulighetForArbeidProps) => {
             margin
             bold
             checked={!!periode.aktivitetIkkeMulig?.arbeidsrelatertArsak}
+            listItems={periode.aktivitetIkkeMulig?.arbeidsrelatertArsak?.arsak.map(
+              (arsak) => ArbeidsrelatertArsakTypeValues[arsak],
+            )}
             vis
           />
           <ElementMedTekst


### PR DESCRIPTION
Idag vises ikke den aktuelle årsaken hvis det er medisinske- eller arbeidsrelaterte årsaker, kun en checkbox med at det er medisinske- eller arbeidsrelaterte årsaker. Kanskje vise det?

![image](https://user-images.githubusercontent.com/25056612/124766334-1dbc3100-df37-11eb-9b09-3b6c0a7321fb.png)
